### PR TITLE
Change untar permissions from 750 to 740

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -36,7 +36,7 @@
         copy: false
         owner: root
         group: root
-        mode: '750'
+        mode: '740'
 
     - name: "[install] create .version file"
       copy:


### PR DESCRIPTION
Because I'm getting this error when trying to run Lynis:

Fatal error: permissions of file /opt/lynis/db/languages/en are not strict enough. Access to 'group' should be read-write, read, or none. Change with: chmod g=r /opt/lynis/db/languages/en
